### PR TITLE
Make assembly path system agnostic

### DIFF
--- a/newtonsoft.json/src/newtonsoft.json.psm1
+++ b/newtonsoft.json/src/newtonsoft.json.psm1
@@ -1,4 +1,4 @@
-$asm = [Reflection.Assembly]::LoadFile($(Join-Path $PSScriptRoot, "libs", "Newtonsoft.Json.dll"))
+$asm = [Reflection.Assembly]::LoadFile($(Join-Path -Path $PSScriptRoot -ChildPath "libs" -AdditionalChildPath "Newtonsoft.Json.dll"))
 
 function ConvertFrom-JObject($obj) {
    if ($obj -is [Newtonsoft.Json.Linq.JArray]) {

--- a/newtonsoft.json/src/newtonsoft.json.psm1
+++ b/newtonsoft.json/src/newtonsoft.json.psm1
@@ -1,4 +1,4 @@
-$asm = [Reflection.Assembly]::LoadFile("$PSScriptRoot\libs\Newtonsoft.Json.dll")
+$asm = [Reflection.Assembly]::LoadFile($(Join-Path $PSScriptRoot, "libs", "Newtonsoft.Json.dll"))
 
 function ConvertFrom-JObject($obj) {
    if ($obj -is [Newtonsoft.Json.Linq.JArray]) {


### PR DESCRIPTION
Hi,
Using this module in Linux/Unix is not possible, because path is hardcoded to slashes. Switching to Join-Path makes it system agnostic.